### PR TITLE
Initial PR for IPC code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,36 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -15,10 +41,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -52,11 +105,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
 name = "humsh"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "crossterm",
+ "tokio",
 ]
 
 [[package]]
@@ -82,6 +149,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +173,25 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -117,6 +218,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +249,12 @@ checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "scopeguard"
@@ -166,6 +297,64 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+dependencies = [
+ "autocfg",
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.72"
 crossterm = "0.26.1"
+tokio = { version = "1.29.1", features = [ "full" ] }
+async-trait = "0.1.71"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::{execute, style::*};
 use std::io::prelude::*;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::Command;
@@ -70,8 +69,8 @@ impl Ipc for Socket {
             match rawconn {
                 Ok(mut conn) => {
                     let mut buf = String::new();
-                    conn.read_to_string(&mut buf).unwrap();
-                    return self.execute(buf);
+                    conn.read_to_string(&mut buf)?;
+                    return Ok(buf);
                 }
                 Err(_) => {}
             }
@@ -84,7 +83,8 @@ pub fn listener() {
     let mut conn = Socket::new().unwrap();
     match conn.recv() {
         Ok(cmd) => {
-            conn.send(cmd).unwrap();
+            let output = conn.execute(cmd).unwrap();
+            conn.send(output).unwrap();
         }
         Err(_) => {}
     };

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -72,29 +72,26 @@ impl Ipc for Socket {
     }
     fn recv(&mut self) -> Result<String> {
         for rawconn in self.listener.incoming() {
-            std::fs::remove_file(SOCK_ADDR)?;
             match rawconn {
                 Ok(mut conn) => {
                     let mut buf = String::new();
                     conn.read_to_string(&mut buf).unwrap();
                     return self.execute(buf);
                 }
-                Err(_) => {
-                    break;
-                }
+                Err(_) => {}
             }
         }
         Ok(String::new())
     }
 }
 
-pub fn listener() -> Result<()> {
-    let mut conn = Socket::new()?;
+pub fn listener() {
+    let mut conn = Socket::new().unwrap();
     match conn.recv() {
         Ok(cmd) => {
-            conn.send(cmd)?;
+            conn.send(cmd).unwrap();
         }
         Err(_) => {}
     };
-    Ok(())
+    std::fs::remove_file(SOCK_ADDR).unwrap();
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -88,14 +88,13 @@ impl Ipc for Socket {
     }
 }
 
-pub fn test() {
-    let mut conn = Socket::new().unwrap();
-    let cmd = String::from("git push");
-    conn.send(cmd).unwrap();
+pub fn listener() -> Result<()> {
+    let mut conn = Socket::new()?;
     match conn.recv() {
         Ok(cmd) => {
-            println!("{}", cmd);
+            conn.send(cmd)?;
         }
         Err(_) => {}
     };
+    Ok(())
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -37,6 +37,7 @@ impl Socket {
         }
     }
     fn execute(&self, cmd: String) -> Result<()> {
+        println!("hi");
         // TODO: replace all this with a nice struct which will represent this data
         let mut parts = cmd.split_whitespace();
 
@@ -61,11 +62,9 @@ impl Ipc for Socket {
     async fn recv(&mut self) -> Result<String> {
         match self.socktype {
             SocketType::Listener => {
-                let (stream, _) = self.listener.as_ref().unwrap().accept().await?;
-                let mut conn = stream.into_std()?;
-                conn.set_nonblocking(false)?;
+                let (mut stream, _) = self.listener.as_ref().unwrap().accept().await?;
                 let mut buf = String::new();
-                conn.read_to_string(&mut buf).unwrap();
+                stream.read_to_string(&mut buf).await?;
                 return Ok(buf);
             }
             SocketType::Stream => match UnixStream::connect(SOCK_ADDR).await {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,13 +1,16 @@
 use anyhow::Result;
-use std::io::prelude::*;
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::process::{Command, Stdio};
+use async_trait::async_trait;
+use std::io::Read;
+use std::process::Command;
+use tokio::io::AsyncReadExt;
+use tokio::net::{UnixListener, UnixStream};
 
 const SOCK_ADDR: &str = "/tmp/humsh.sock";
 
+#[async_trait]
 pub trait Ipc {
-    fn send(&mut self, cmd: String) -> Result<()>;
-    fn recv(&mut self) -> Result<String>;
+    async fn send(&mut self, cmd: String) -> Result<()>;
+    async fn recv(&mut self) -> Result<String>;
 }
 
 enum SocketType {
@@ -33,56 +36,42 @@ impl Socket {
             }),
         }
     }
-    fn execute(&self, cmd: String) -> Result<String> {
+    fn execute(&self, cmd: String) -> Result<()> {
         // TODO: replace all this with a nice struct which will represent this data
         let mut parts = cmd.split_whitespace();
 
         if let Some(program) = parts.next() {
             let args: Vec<_> = parts.collect();
-
-            let mut cmd = Command::new(program);
-            cmd.args(args);
-            cmd.stdout(Stdio::piped());
-            cmd.stderr(Stdio::piped());
-
-            let mut child = cmd.spawn()?;
-
-            let mut output = String::new();
-            child.stderr.as_mut().unwrap().read_to_string(&mut output)?;
-            return Ok(output);
+            Command::new(program).args(args).spawn()?;
         }
-        Ok(String::new())
+        Ok(())
     }
 }
 
 // Send and receive information from other processes through a Unix socket
 //
 // The socket is already predefined
+#[async_trait]
 impl Ipc for Socket {
-    fn send(&mut self, cmd: String) -> Result<()> {
-        let mut stream = UnixStream::connect(SOCK_ADDR)?;
-        stream.write_all(cmd.as_bytes())?;
+    async fn send(&mut self, cmd: String) -> Result<()> {
+        let stream = UnixStream::connect(SOCK_ADDR).await?;
+        stream.try_write(cmd.as_bytes())?;
         Ok(())
     }
-    fn recv(&mut self) -> Result<String> {
+    async fn recv(&mut self) -> Result<String> {
         match self.socktype {
             SocketType::Listener => {
-                let listener = self.listener.as_ref().unwrap();
-                for rawconn in listener.incoming() {
-                    match rawconn {
-                        Ok(mut conn) => {
-                            let mut buf = String::new();
-                            conn.read_to_string(&mut buf)?;
-                            return Ok(buf);
-                        }
-                        Err(_) => {}
-                    }
-                }
+                let (stream, _) = self.listener.as_ref().unwrap().accept().await?;
+                let mut conn = stream.into_std()?;
+                conn.set_nonblocking(false)?;
+                let mut buf = String::new();
+                conn.read_to_string(&mut buf).unwrap();
+                return Ok(buf);
             }
-            SocketType::Stream => match UnixStream::connect(SOCK_ADDR) {
+            SocketType::Stream => match UnixStream::connect(SOCK_ADDR).await {
                 Ok(mut stream) => {
                     let mut buf = String::new();
-                    stream.read_to_string(&mut buf)?;
+                    stream.read_to_string(&mut buf).await?;
                     return Ok(buf);
                 }
                 Err(_) => {}
@@ -92,12 +81,11 @@ impl Ipc for Socket {
     }
 }
 
-pub fn listener() {
+pub async fn listener() {
     let mut conn = Socket::new().unwrap();
-    match conn.recv() {
+    match conn.recv().await {
         Ok(cmd) => {
-            let output = conn.execute(cmd).unwrap();
-            conn.send(output).unwrap();
+            conn.execute(cmd).unwrap();
         }
         Err(_) => {}
     };

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -16,7 +16,7 @@ pub struct Socket {
 }
 
 impl Socket {
-    fn new() -> Result<Socket> {
+    pub fn new() -> Result<Socket> {
         Ok(Socket {
             listener: UnixListener::bind(SOCK_ADDR)?,
         })

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -27,6 +27,7 @@ impl Socket {
             stdout,
             PrintStyledContent(format!("> {cmd}\n").with(Color::DarkGreen))
         )?;
+        // TODO: replace all this with a nice struct which will represent this data
         let mut parts = cmd.split_whitespace();
 
         if let Some(program) = parts.next() {
@@ -40,6 +41,8 @@ impl Socket {
                     let result = child.wait_with_output();
                     match result {
                         Ok(status) => {
+                            // the output of the command on STDOUT
+                            // TODO: handle STDERR as well
                             return Ok(String::from_utf8(status.stdout)?);
                         }
                         Err(err) => {
@@ -58,6 +61,9 @@ impl Socket {
     }
 }
 
+// Send and receive information from other processes through a Unix socket
+//
+// The socket is already predefined
 impl Ipc for Socket {
     fn send(&mut self, cmd: String) -> Result<()> {
         let mut stream = UnixStream::connect(SOCK_ADDR)?;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -22,11 +22,6 @@ impl Socket {
         })
     }
     fn execute(&self, cmd: String) -> Result<String> {
-        let mut stdout = std::io::stdout().lock();
-        execute!(
-            stdout,
-            PrintStyledContent(format!("> {cmd}\n").with(Color::DarkGreen))
-        )?;
         // TODO: replace all this with a nice struct which will represent this data
         let mut parts = cmd.split_whitespace();
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use std::io::prelude::*;
+use std::os::unix::net::{UnixListener, UnixStream};
+
+const SOCK_ADDR: &str = "/tmp/humsh.sock";
+
+pub trait Ipc {
+    fn send(&mut self, cmd: String) -> Result<()>;
+    fn recv(&mut self) -> Result<String>;
+}
+
+pub struct Socket {
+    listener: UnixListener,
+}
+
+impl Socket {
+    fn new() -> Result<Socket> {
+        Ok(Socket {
+            listener: UnixListener::bind(SOCK_ADDR)?,
+        })
+    }
+}
+
+impl Ipc for Socket {
+    fn send(&mut self, cmd: String) -> Result<()> {
+        let mut stream = UnixStream::connect(SOCK_ADDR)?;
+        stream.write_all(cmd.as_bytes())?;
+        Ok(())
+    }
+    fn recv(&mut self) -> Result<String> {
+        for rawconn in self.listener.incoming() {
+            std::fs::remove_file(SOCK_ADDR)?;
+            match rawconn {
+                Ok(mut conn) => {
+                    let mut buf = String::new();
+                    conn.read_to_string(&mut buf).unwrap();
+                    return Ok(buf);
+                }
+                Err(_) => {
+                    break;
+                }
+            }
+        }
+        Ok(String::new())
+    }
+}
+
+pub fn test() {
+    let mut conn = Socket::new().unwrap();
+    let cmd = String::from("git push");
+    conn.send(cmd).unwrap();
+    match conn.recv() {
+        Ok(cmd) => {
+            println!("{}", cmd);
+        }
+        Err(_) => {}
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,19 @@
 #![allow(dead_code)]
 use anyhow::Result;
-use std::env;
 
 mod command_line;
 mod data;
 mod ipc;
 mod ui;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() == 2 && args[1] == "listen" {
-        ipc::listener();
-    } else {
-        let program = data::git_push();
-        ui::Ui::new(program).run()?;
-    }
+#[tokio::main]
+async fn main() -> Result<()> {
+    tokio::task::spawn(async move {
+        loop {
+            ipc::listener().await;
+        }
+    });
+    let program = data::git_push();
+    ui::Ui::new(program).run().await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use anyhow::Result;
+use std::env;
 
 mod command_line;
 mod data;
@@ -7,7 +8,12 @@ mod ipc;
 mod ui;
 
 fn main() -> Result<()> {
-    let program = data::git_push();
-    ui::Ui::new(program).run()?;
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 2 && args[1] == "listen" {
+        ipc::listener();
+    } else {
+        let program = data::git_push();
+        ui::Ui::new(program).run()?;
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 
 mod command_line;
 mod data;
+mod ipc;
 mod ui;
 
 fn main() -> Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -30,7 +30,7 @@ impl Ui {
         }
     }
 
-    pub fn run(mut self) -> anyhow::Result<()> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         let mut stdout = std::io::stdout().lock();
         self.enter_ui(&mut stdout)?;
         loop {
@@ -56,8 +56,7 @@ impl Ui {
                         PrintStyledContent(format!("> {cli}\n").with(Color::DarkGreen))
                     )?;
                     let mut sock = Socket::new()?;
-                    sock.send(cli)?;
-                    println!("{}", sock.recv()?);
+                    sock.send(cli).await?;
                     self.enter_ui(&mut stdout)?;
                 }
                 Some(Action::ToggleCmd) => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,6 +4,7 @@ use crossterm::event::{self, Event};
 use crossterm::{cursor, execute, queue, style::*, terminal};
 
 use crate::data::Action;
+use crate::ipc::{Ipc, Socket};
 use crate::{
     command_line::CommandLine,
     data::{self, Button, Group, Page},
@@ -54,10 +55,15 @@ impl Ui {
                         stdout,
                         PrintStyledContent(format!("> {cli}\n").with(Color::DarkGreen))
                     )?;
+                    /*
                     self.command_line.to_std().spawn()?.wait()?;
                     if exit {
                         break Ok(());
                     }
+                    */
+                    let mut sock = Socket::new()?;
+                    sock.send(cli)?;
+                    println!("{}", sock.recv()?);
                     self.enter_ui(&mut stdout)?;
                 }
                 Some(Action::ToggleCmd) => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -55,12 +55,6 @@ impl Ui {
                         stdout,
                         PrintStyledContent(format!("> {cli}\n").with(Color::DarkGreen))
                     )?;
-                    /*
-                    self.command_line.to_std().spawn()?.wait()?;
-                    if exit {
-                        break Ok(());
-                    }
-                    */
                     let mut sock = Socket::new()?;
                     sock.send(cli)?;
                     println!("{}", sock.recv()?);


### PR DESCRIPTION
This will help add the ability to use a different thread for actually running shell commands and frees up the UI thread. It uses a Unix socket (non-portable) for this, and doesn't actually run commands right now.

Goals now are:

- Replace all `execute!` calls present in `ui.rs` with IPC calls
- fork+exec a process for handling IPC calls and send the response back to the UI process