### PR TITLE
Add shell dependencies to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   in
   {
     devShells.${system}.default = pkgs.mkShell {
-      nativeBuildInputs = with pkgs; [ cargo rustc rustfmt rust-analyzer ];
+      nativeBuildInputs = with pkgs; [ cargo rustc rustfmt rust-analyzer starship zoxide fish fzf ];
     };
   };
 }


### PR DESCRIPTION
This add zoxide, fish etc to the `flake.nix` so it is easy to get started using these tools if you don't have much experience.